### PR TITLE
fix(tunnel): session.list 502 + session.history 载入历史 8x 加速

### DIFF
--- a/lib/tunnel-client.mjs
+++ b/lib/tunnel-client.mjs
@@ -233,10 +233,13 @@ export class CustomTunnelClient {
       };
 
       let total = 0;
+      const cleanPath = String(path || '').split('?')[0];
+      // session.list 会在 end 后剥离 contextHeaders 等大字段，跳过 data 阶段的大小检查
+      const skipSizeCheck = cleanPath === '/api/session.list';
       res.on('data', (c) => {
         chunks.push(c);
         total += c.length;
-        if (total > MAX_RESPONSE_BYTES) {
+        if (!skipSizeCheck && total > MAX_RESPONSE_BYTES) {
           sendResponse(502, { 'content-type': 'text/plain' },
             `Response too large for tunnel (>${Math.round(MAX_RESPONSE_BYTES / 1024 / 1024)}MB cap)`);
           res.destroy();
@@ -254,7 +257,6 @@ export class CustomTunnelClient {
 
         // session.list 响应可能极大（数百会话 × contextHeaders = 60MB+）
         // 剥离 contextHeaders 和 contextTimeline（侧边栏列表不需要，打开会话时通过 WebSocket 实时获取）
-        const cleanPath = String(path || '').split('?')[0];
         if (cleanPath === '/api/session.list' && res.statusCode === 200) {
           try {
             const json = JSON.parse(bodyBuf.toString('utf8'));

--- a/lib/tunnel-client.mjs
+++ b/lib/tunnel-client.mjs
@@ -255,18 +255,30 @@ export class CustomTunnelClient {
         );
         let bodyBuf = Buffer.concat(chunks);
 
-        // session.list 响应可能极大（数百会话 × contextHeaders = 60MB+）
-        // 剥离 contextHeaders 和 contextTimeline（侧边栏列表不需要，打开会话时通过 WebSocket 实时获取）
-        if (cleanPath === '/api/session.list' && res.statusCode === 200) {
+        // 剥离 contextHeaders 和 contextTimeline — 这两个投影字段包含每轮完整
+        // 系统提示+工具定义（4.8MB+），但没有任何客户端 UI 读取它们。
+        // session.list: 数百会话 × contextHeaders = 60MB+
+        // session.history: 单会话 contextHeaders = 4.8MB，占响应 80%+
+        // 剥离后 session.history 从 1.2MB gzip 降到 ~150KB（8x 减少）
+        if ((cleanPath === '/api/session.list' || cleanPath === '/api/session.history') && res.statusCode === 200) {
           try {
             const json = JSON.parse(bodyBuf.toString('utf8'));
-            if (json?.result?.ok && json.result.value?.items) {
-              for (const item of json.result.value.items) {
-                const proj = item?.projections?.values;
-                if (proj) {
-                  delete proj.contextHeaders;
-                  delete proj.contextTimeline;
+            if (json?.result?.ok) {
+              const v = json.result.value;
+              // session.list: items[].projections.values
+              if (v?.items) {
+                for (const item of v.items) {
+                  const proj = item?.projections?.values;
+                  if (proj) {
+                    delete proj.contextHeaders;
+                    delete proj.contextTimeline;
+                  }
                 }
+              }
+              // session.history: projections.values
+              if (v?.projections?.values) {
+                delete v.projections.values.contextHeaders;
+                delete v.projections.values.contextTimeline;
               }
               bodyBuf = Buffer.from(JSON.stringify(json), 'utf8');
               respHeaders['content-length'] = String(bodyBuf.length);


### PR DESCRIPTION
## 修复 1：32MB 大小检查在 contextHeaders 剥离前触发导致 session.list 502

v2.9.0 新增 `MAX_RESPONSE_BYTES = 32MB` 检查在 `res.on('data')` 中，但 `contextHeaders` 剥离在 `res.on('end')` 中执行。`session.list` 原始响应 71MB > 32MB，在 data 阶段被 502 截断，剥离代码未执行。

**修复**：对 `/api/session.list` 跳过 data 阶段大小检查（end 后会剥离到 ~300KB）。

## 修复 2：剥离 session.history 的 contextHeaders 投影 — 载入历史 8x 加速

`session.history` 响应的 `projections.values.contextHeaders` 包含每轮完整系统提示+工具定义（4.8MB），占响应 80%+，但没有任何客户端 UI 读取它。

| 指标 | 修复前 | 修复后 | 改善 |
|------|--------|--------|------|
| 响应大小（gzip） | 1,220 KB | 164 KB | 8x ↓ |
| 载入时间（3M 带宽） | ~8s | ~1.4s | 5x ↓ |
| 事件数 | 2917 | 2917 | 不变 |
| 轨迹视图 | ✅ | ✅ | 不变 |

`request/header` 事件未被触碰，轨迹视图（Trajectory）正常工作。

## 验证

```
session.list:    HTTP 200, 40KB, 2.5s
session.history: HTTP 200, 164KB, 1.4s (was 1.2MB, 8s)
```

## 关联

- PR #21 已合并 SSE 504 和 session.list contextHeaders 剥离修复
- 本 PR 在其基础上修复 v2.9.0 的 32MB 回归 + 新增 session.history 剥离
