### PR TITLE
feat(tunnel): add SSE streaming passthrough for custom tunnels

### DIFF
--- a/client/client.js
+++ b/client/client.js
@@ -1413,9 +1413,10 @@ var CustomTunnelGuide = React.memo(function CustomTunnelGuide2() {
     }, "\u67E5\u770B\u81EA\u5EFA\u96A7\u9053\u670D\u52A1\u5668\u642D\u5EFA\u6559\u7A0B")
   );
 });
-var CustomTunnelConfigForm = React.memo(function CustomTunnelConfigForm2({ serverUrl: initUrl, accessToken: initToken, onSave }) {
+var CustomTunnelConfigForm = React.memo(function CustomTunnelConfigForm2({ serverUrl: initUrl, accessToken: initToken, sseStreaming: initSse, onSave }) {
   const [serverUrl, setServerUrl] = React.useState(initUrl ?? "");
   const [accessToken, setAccessToken] = React.useState(initToken ?? "");
+  const [sseStreaming, setSseStreaming] = React.useState(Boolean(initSse));
   const [saving, setSaving] = React.useState(false);
   const [saveSuccess, setSaveSuccess] = React.useState(false);
   const syncedRef = React.useRef(false);
@@ -1426,14 +1427,15 @@ var CustomTunnelConfigForm = React.memo(function CustomTunnelConfigForm2({ serve
       syncedRef.current = true;
     }
   }, [initUrl, initToken]);
-  const dirty = serverUrl !== (initUrl ?? "") || accessToken !== (initToken ?? "");
+  React.useEffect(() => { setSseStreaming(Boolean(initSse)); }, [initSse]);
+  const dirty = serverUrl !== (initUrl ?? "") || accessToken !== (initToken ?? "") || sseStreaming !== Boolean(initSse);
   const [saveErr, setSaveErr] = React.useState(null);
   const handleSave = React.useCallback(async () => {
     setSaving(true);
     setSaveSuccess(false);
     setSaveErr(null);
     try {
-      await onSave(serverUrl, accessToken);
+      await onSave(serverUrl, accessToken, sseStreaming);
       setSaveSuccess(true);
       setTimeout(() => setSaveSuccess(false), 2500);
     } catch (e) {
@@ -1441,7 +1443,7 @@ var CustomTunnelConfigForm = React.memo(function CustomTunnelConfigForm2({ serve
     } finally {
       setSaving(false);
     }
-  }, [onSave, serverUrl, accessToken]);
+  }, [onSave, serverUrl, accessToken, sseStreaming]);
   const handleUrlChange = React.useCallback((e) => {
     setServerUrl(e.target.value);
     setSaveSuccess(false);
@@ -1485,6 +1487,29 @@ var CustomTunnelConfigForm = React.memo(function CustomTunnelConfigForm2({ serve
         "div",
         { style: { ...s.muted, fontSize: 11 } },
         "\u{1F4A1} \u7528\u4E8E\u4E0E\u60A8\u7684 VPS \u96A7\u9053\u670D\u52A1\u7AEF\u5EFA\u7ACB\u53CD\u5411\u901A\u9053\uFF08\u4E0E Web \u7F51\u9875\u8BBF\u5BA2\u8BBF\u95EE\u5BC6\u7801\u4E92\u76F8\u72EC\u7ACB\uFF09\u3002"
+      ),
+      React.createElement(
+        "label",
+        {
+          style: {
+            display: "flex",
+            alignItems: "center",
+            gap: 8,
+            cursor: "pointer",
+            fontSize: 12,
+            color: "var(--dsw-alias-label-secondary,#6b7280)",
+            userSelect: "none",
+            marginTop: 4
+          }
+        },
+        React.createElement("input", {
+          type: "checkbox",
+          checked: sseStreaming,
+          onChange: (e) => { setSseStreaming(e.target.checked); setSaveSuccess(false); setSaveErr(null); },
+          disabled: saving,
+          style: { cursor: "pointer" }
+        }),
+        "SSE \u6D41\u5F0F\u8F6C\u53D1\uFF08\u9700\u670D\u52A1\u7AEF\u652F\u6301\u6D41\u5F0F\u534F\u8BAE\uFF0C\u5173\u95ED\u5219\u4F7F\u7528\u622A\u65AD\u6A21\u5F0F\uFF09"
       ),
       React.createElement("button", {
         style: {
@@ -4005,7 +4030,7 @@ function BridgePanel({ rpcCall }) {
     [act]
   );
   const saveConfig = React.useCallback(
-    (serverUrl, accessToken) => act(BRIDGE_ENDPOINTS.saveCustomTunnelConfig, { serverUrl, accessToken }),
+    (serverUrl, accessToken, sseStreaming) => act(BRIDGE_ENDPOINTS.saveCustomTunnelConfig, { serverUrl, accessToken, sseStreaming }),
     [act]
   );
   const saveExternalTunnel = React.useCallback(
@@ -4101,6 +4126,7 @@ function BridgePanel({ rpcCall }) {
         React.createElement(CustomTunnelConfigForm, {
           serverUrl: ct?.serverUrl ?? "",
           accessToken: ct?.accessToken ?? "",
+          sseStreaming: ct?.sseStreaming,
           onSave: saveConfig
         })
       )

--- a/client/client.js
+++ b/client/client.js
@@ -823,6 +823,37 @@ var MOBILE_STYLES_CSS = `
       to { transform: translateY(0); }
     }
 
+    /* 深色模式适配：目录浏览器弹窗使用了 DSH 主题系统未定义的 state-*-bg / state-*-border / state-*-primary 变量 */
+    body[data-ds-dark-theme] {
+      --dsw-alias-state-info-bg: rgba(65, 118, 230, 0.12);
+      --dsw-alias-state-info-border: rgba(65, 118, 230, 0.25);
+      --dsw-alias-state-info-primary: #60a5fa;
+      --dsw-alias-state-success-bg: rgba(34, 197, 94, 0.12);
+      --dsw-alias-state-success-border: rgba(34, 197, 94, 0.25);
+      --dsw-alias-state-success-primary: #4ade80;
+      --dsw-alias-state-warn-bg: rgba(245, 158, 11, 0.12);
+      --dsw-alias-state-warn-border: rgba(245, 158, 11, 0.25);
+      --dsw-alias-state-warn-primary: #fbbf24;
+      --dsw-alias-state-error-bg: rgba(239, 68, 68, 0.12);
+      --dsw-alias-state-error-border: rgba(239, 68, 68, 0.25);
+      --dsw-alias-state-error-primary: #f87171;
+    }
+
+    /* 深色模式：直接覆盖弹窗内所有使用 #fff/#ffffff fallback 的内联背景，
+       确保即使 CSS 变量未正确继承，弹窗也不会显示白色背景 */
+    body[data-ds-dark-theme] #dsh-remote-workspace-modal .dsh-ws-dialog-card,
+    body[data-ds-dark-theme] #dsh-remote-workspace-modal .dsh-ws-dialog-card * {
+      --dsw-alias-bg-layer-1: #1b1b1c;
+      --dsw-alias-bg-layer-2: #2c2c2e;
+      --dsw-alias-bg-layer-3: #353638;
+      --dsw-alias-border-l2: #3c3c3d;
+      --dsw-alias-label-primary: #f9fafb;
+      --dsw-alias-label-secondary: #adb2b8;
+      --dsw-alias-label-tertiary: #81858c;
+      --dsw-alias-brand-primary: #f9fafb;
+      --dsw-alias-label-primary-foreground: #0f1115;
+    }
+
     @media (min-width: 769px) {
       .dsh-mobile-app-header,
       .dsh-mobile-backdrop,
@@ -4855,7 +4886,7 @@ function showRemoteWorkspaceDialog(rpcCall, onWorkspaceAdded, clientCtx, onPicke
           <form id="dsh-ws-unlock-form" style="display: flex; gap: 8px;">
             <input id="dsh-ws-unlock-input" type="password" placeholder="\u8BF7\u8F93\u5165\u540E\u53F0\u7BA1\u7406\u5BC6\u7801" value="${escapeHtml(unlockInput)}"
               style="flex: 1; font: inherit; font-size: 13px; padding: 7px 10px; border-radius: 8px; border: 1px solid var(--dsw-alias-border-l2, #d1d5db); background: var(--dsw-alias-bg-layer-1, #fff); color: var(--dsw-alias-label-primary, currentColor); outline: none; box-sizing: border-box;" />
-            <button type="submit" style="border: none; background: var(--dsw-alias-brand-primary, #4f6ef7); color: #fff; border-radius: 8px; padding: 0 14px; font-size: 12px; font-weight: 600; cursor: pointer; flex-shrink: 0;" ${unlocking ? "disabled" : ""}>${unlocking ? "\u89E3\u9501\u4E2D\u2026" : "\u89E3\u9501"}</button>
+            <button type="submit" style="border: none; background: var(--dsw-static-blue-600, #4f6ef7); color: #fff; border-radius: 8px; padding: 0 14px; font-size: 12px; font-weight: 600; cursor: pointer; flex-shrink: 0;" ${unlocking ? "disabled" : ""}>${unlocking ? "\u89E3\u9501\u4E2D\u2026" : "\u89E3\u9501"}</button>
           </form>
           ${unlockErr ? `<div style="font-size: 11px; color: var(--dsw-alias-state-error-primary, #dc2626); margin-top: 6px;">${escapeHtml(unlockErr)}</div>` : ""}
         </div>
@@ -4875,7 +4906,7 @@ function showRemoteWorkspaceDialog(rpcCall, onWorkspaceAdded, clientCtx, onPicke
           ${(drives || []).map((d) => {
       const isActive = currentPath.startsWith(d.path) || currentPath === d.path;
       return `
-              <button class="dsh-ws-quick-btn" data-path="${escapeHtml(d.path)}" style="border: 1px solid ${isActive ? "var(--dsw-alias-brand-primary, #4f6ef7)" : "var(--dsw-alias-border-l2, #d1d5db)"}; background: ${isActive ? "var(--dsw-alias-brand-primary, #4f6ef7)" : "var(--dsw-alias-bg-layer-2, #f9fafb)"}; color: ${isActive ? "#fff" : "var(--dsw-alias-label-primary, #111827)"}; border-radius: 14px; padding: 4px 10px; font-size: 11px; cursor: pointer; font-weight: 500; flex-shrink: 0; transition: all 0.1s;">
+              <button class="dsh-ws-quick-btn" data-path="${escapeHtml(d.path)}" style="border: 1px solid ${isActive ? "var(--dsw-static-blue-600, #4f6ef7)" : "var(--dsw-alias-border-l2, #d1d5db)"}; background: ${isActive ? "var(--dsw-static-blue-600, #4f6ef7)" : "var(--dsw-alias-bg-layer-2, #f9fafb)"}; color: ${isActive ? "#fff" : "var(--dsw-alias-label-primary, #111827)"}; border-radius: 14px; padding: 4px 10px; font-size: 11px; cursor: pointer; font-weight: 500; flex-shrink: 0; transition: all 0.1s;">
                 \u{1F4BE} ${escapeHtml(d.name)}
               </button>
             `;
@@ -4922,9 +4953,9 @@ function showRemoteWorkspaceDialog(rpcCall, onWorkspaceAdded, clientCtx, onPicke
         <div style="background: var(--dsw-alias-state-info-bg, #eff6ff); border: 1px solid var(--dsw-alias-state-info-border, #bfdbfe); border-radius: 10px; padding: 10px 12px; display: flex; flex-direction: column; gap: 6px;">
           <div style="display: flex; align-items: center; justify-content: space-between; gap: 6px;">
             <span style="font-size: 11px; font-weight: 600; color: var(--dsw-alias-brand-primary, #2563eb); flex-shrink: 0;">\u5F53\u524D\u76EE\u5F55:</span>
-            <span style="font-family: ui-monospace, Menlo, monospace; font-size: 11px; color: var(--dsw-alias-label-primary, #1e3a8a); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; flex: 1; text-align: right; font-weight: 600;">${escapeHtml(currentPath)}</span>
+            <span style="font-family: ui-monospace, Menlo, monospace; font-size: 11px; color: var(--dsw-alias-label-primary, var(--dsw-alias-brand-primary, #1e3a8a)); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; flex: 1; text-align: right; font-weight: 600;">${escapeHtml(currentPath)}</span>
           </div>
-          <button id="dsh-ws-add-current-btn" style="border: none; background: var(--dsw-alias-brand-primary, #2563eb); color: #fff; height: 36px; border-radius: 8px; font-size: 13px; font-weight: 600; cursor: pointer; display: flex; align-items: center; justify-content: center; gap: 6px; width: 100%; box-shadow: 0 2px 4px rgba(37,99,235,0.25); transition: opacity 0.1s;" ${isSubmitting ? "disabled" : ""}>
+          <button id="dsh-ws-add-current-btn" style="border: none; background: var(--dsw-static-blue-600, #2563eb); color: #fff; height: 36px; border-radius: 8px; font-size: 13px; font-weight: 600; cursor: pointer; display: flex; align-items: center; justify-content: center; gap: 6px; width: 100%; box-shadow: 0 2px 4px rgba(37,99,235,0.25); transition: opacity 0.1s;" ${isSubmitting ? "disabled" : ""}>
             ${isSubmitting ? "\u6B63\u5728\u6DFB\u52A0\u5E76\u5207\u6362\u2026" : "\u{1F449} \u8BBE\u4E3A\u5F53\u524D\u5DE5\u4F5C\u533A\u5E76\u8FDB\u5165"}
           </button>
         </div>
@@ -4983,7 +5014,7 @@ function showRemoteWorkspaceDialog(rpcCall, onWorkspaceAdded, clientCtx, onPicke
               <button id="dsh-ws-manual-jump-btn" style="border: 1px solid var(--dsw-alias-border-l2, #d1d5db); background: var(--dsw-alias-bg-layer-2, #f9fafb); color: var(--dsw-alias-label-primary, #111827); padding: 0 10px; border-radius: 8px; font-size: 11px; cursor: pointer; white-space: nowrap;">
                 \u524D\u5F80
               </button>
-              <button id="dsh-ws-manual-add-btn" style="border: none; background: var(--dsw-alias-brand-primary, #4f6ef7); color: #fff; padding: 0 12px; border-radius: 8px; font-size: 11px; font-weight: 500; cursor: pointer; white-space: nowrap;">
+              <button id="dsh-ws-manual-add-btn" style="border: none; background: var(--dsw-static-blue-600, #4f6ef7); color: #fff; padding: 0 12px; border-radius: 8px; font-size: 11px; font-weight: 500; cursor: pointer; white-space: nowrap;">
                 \u6DFB\u52A0\u5E76\u8FDB\u5165
               </button>
             </div>

--- a/client/index.js
+++ b/client/index.js
@@ -3633,7 +3633,7 @@ function showRemoteWorkspaceDialog(rpcCall, onWorkspaceAdded, clientCtx, onPicke
           <form id="dsh-ws-unlock-form" style="display: flex; gap: 8px;">
             <input id="dsh-ws-unlock-input" type="password" placeholder="请输入后台管理密码" value="${escapeHtml(unlockInput)}"
               style="flex: 1; font: inherit; font-size: 13px; padding: 7px 10px; border-radius: 8px; border: 1px solid var(--dsw-alias-border-l2, #d1d5db); background: var(--dsw-alias-bg-layer-1, #fff); color: var(--dsw-alias-label-primary, currentColor); outline: none; box-sizing: border-box;" />
-            <button type="submit" style="border: none; background: var(--dsw-alias-brand-primary, #4f6ef7); color: #fff; border-radius: 8px; padding: 0 14px; font-size: 12px; font-weight: 600; cursor: pointer; flex-shrink: 0;" ${unlocking ? 'disabled' : ''}>${unlocking ? '解锁中…' : '解锁'}</button>
+            <button type="submit" style="border: none; background: var(--dsw-static-blue-600, #4f6ef7); color: #fff; border-radius: 8px; padding: 0 14px; font-size: 12px; font-weight: 600; cursor: pointer; flex-shrink: 0;" ${unlocking ? 'disabled' : ''}>${unlocking ? '解锁中…' : '解锁'}</button>
           </form>
           ${unlockErr ? `<div style="font-size: 11px; color: var(--dsw-alias-state-error-primary, #dc2626); margin-top: 6px;">${escapeHtml(unlockErr)}</div>` : ''}
         </div>
@@ -3653,7 +3653,7 @@ function showRemoteWorkspaceDialog(rpcCall, onWorkspaceAdded, clientCtx, onPicke
           ${(drives || []).map(d => {
             const isActive = currentPath.startsWith(d.path) || currentPath === d.path;
             return `
-              <button class="dsh-ws-quick-btn" data-path="${escapeHtml(d.path)}" style="border: 1px solid ${isActive ? 'var(--dsw-alias-brand-primary, #4f6ef7)' : 'var(--dsw-alias-border-l2, #d1d5db)'}; background: ${isActive ? 'var(--dsw-alias-brand-primary, #4f6ef7)' : 'var(--dsw-alias-bg-layer-2, #f9fafb)'}; color: ${isActive ? '#fff' : 'var(--dsw-alias-label-primary, #111827)'}; border-radius: 14px; padding: 4px 10px; font-size: 11px; cursor: pointer; font-weight: 500; flex-shrink: 0; transition: all 0.1s;">
+              <button class="dsh-ws-quick-btn" data-path="${escapeHtml(d.path)}" style="border: 1px solid ${isActive ? 'var(--dsw-static-blue-600, #4f6ef7)' : 'var(--dsw-alias-border-l2, #d1d5db)'}; background: ${isActive ? 'var(--dsw-static-blue-600, #4f6ef7)' : 'var(--dsw-alias-bg-layer-2, #f9fafb)'}; color: ${isActive ? '#fff' : 'var(--dsw-alias-label-primary, #111827)'}; border-radius: 14px; padding: 4px 10px; font-size: 11px; cursor: pointer; font-weight: 500; flex-shrink: 0; transition: all 0.1s;">
                 💾 ${escapeHtml(d.name)}
               </button>
             `;
@@ -3700,9 +3700,9 @@ function showRemoteWorkspaceDialog(rpcCall, onWorkspaceAdded, clientCtx, onPicke
         <div style="background: var(--dsw-alias-state-info-bg, #eff6ff); border: 1px solid var(--dsw-alias-state-info-border, #bfdbfe); border-radius: 10px; padding: 10px 12px; display: flex; flex-direction: column; gap: 6px;">
           <div style="display: flex; align-items: center; justify-content: space-between; gap: 6px;">
             <span style="font-size: 11px; font-weight: 600; color: var(--dsw-alias-brand-primary, #2563eb); flex-shrink: 0;">当前目录:</span>
-            <span style="font-family: ui-monospace, Menlo, monospace; font-size: 11px; color: var(--dsw-alias-label-primary, #1e3a8a); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; flex: 1; text-align: right; font-weight: 600;">${escapeHtml(currentPath)}</span>
+            <span style="font-family: ui-monospace, Menlo, monospace; font-size: 11px; color: var(--dsw-alias-label-primary, var(--dsw-alias-brand-primary, #1e3a8a)); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; flex: 1; text-align: right; font-weight: 600;">${escapeHtml(currentPath)}</span>
           </div>
-          <button id="dsh-ws-add-current-btn" style="border: none; background: var(--dsw-alias-brand-primary, #2563eb); color: #fff; height: 36px; border-radius: 8px; font-size: 13px; font-weight: 600; cursor: pointer; display: flex; align-items: center; justify-content: center; gap: 6px; width: 100%; box-shadow: 0 2px 4px rgba(37,99,235,0.25); transition: opacity 0.1s;" ${isSubmitting ? 'disabled' : ''}>
+          <button id="dsh-ws-add-current-btn" style="border: none; background: var(--dsw-static-blue-600, #2563eb); color: #fff; height: 36px; border-radius: 8px; font-size: 13px; font-weight: 600; cursor: pointer; display: flex; align-items: center; justify-content: center; gap: 6px; width: 100%; box-shadow: 0 2px 4px rgba(37,99,235,0.25); transition: opacity 0.1s;" ${isSubmitting ? 'disabled' : ''}>
             ${isSubmitting ? '正在添加并切换…' : '👉 设为当前工作区并进入'}
           </button>
         </div>
@@ -3761,7 +3761,7 @@ function showRemoteWorkspaceDialog(rpcCall, onWorkspaceAdded, clientCtx, onPicke
               <button id="dsh-ws-manual-jump-btn" style="border: 1px solid var(--dsw-alias-border-l2, #d1d5db); background: var(--dsw-alias-bg-layer-2, #f9fafb); color: var(--dsw-alias-label-primary, #111827); padding: 0 10px; border-radius: 8px; font-size: 11px; cursor: pointer; white-space: nowrap;">
                 前往
               </button>
-              <button id="dsh-ws-manual-add-btn" style="border: none; background: var(--dsw-alias-brand-primary, #4f6ef7); color: #fff; padding: 0 12px; border-radius: 8px; font-size: 11px; font-weight: 500; cursor: pointer; white-space: nowrap;">
+              <button id="dsh-ws-manual-add-btn" style="border: none; background: var(--dsw-static-blue-600, #4f6ef7); color: #fff; padding: 0 12px; border-radius: 8px; font-size: 11px; font-weight: 500; cursor: pointer; white-space: nowrap;">
                 添加并进入
               </button>
             </div>

--- a/client/mobile-styles.js
+++ b/client/mobile-styles.js
@@ -792,6 +792,38 @@ export const MOBILE_STYLES_CSS = `
       to { transform: translateY(0); }
     }
 
+    /* 深色模式适配：dsh-bridge 目录浏览器弹窗使用了 DSH 主题系统未定义的
+       state-*-bg / state-*-border / state-*-primary 变量，补上深色模式值，避免浅色 fallback 永远生效 */
+    body[data-ds-dark-theme] {
+      --dsw-alias-state-info-bg: rgba(65, 118, 230, 0.12);
+      --dsw-alias-state-info-border: rgba(65, 118, 230, 0.25);
+      --dsw-alias-state-info-primary: #60a5fa;
+      --dsw-alias-state-success-bg: rgba(34, 197, 94, 0.12);
+      --dsw-alias-state-success-border: rgba(34, 197, 94, 0.25);
+      --dsw-alias-state-success-primary: #4ade80;
+      --dsw-alias-state-warn-bg: rgba(245, 158, 11, 0.12);
+      --dsw-alias-state-warn-border: rgba(245, 158, 11, 0.25);
+      --dsw-alias-state-warn-primary: #fbbf24;
+      --dsw-alias-state-error-bg: rgba(239, 68, 68, 0.12);
+      --dsw-alias-state-error-border: rgba(239, 68, 68, 0.25);
+      --dsw-alias-state-error-primary: #f87171;
+    }
+
+    /* 深色模式：直接覆盖弹窗内所有使用 #fff/#ffffff fallback 的内联背景，
+       确保即使 CSS 变量未正确继承，弹窗也不会显示白色背景 */
+    body[data-ds-dark-theme] #dsh-remote-workspace-modal .dsh-ws-dialog-card,
+    body[data-ds-dark-theme] #dsh-remote-workspace-modal .dsh-ws-dialog-card * {
+      --dsw-alias-bg-layer-1: #1b1b1c;
+      --dsw-alias-bg-layer-2: #2c2c2e;
+      --dsw-alias-bg-layer-3: #353638;
+      --dsw-alias-border-l2: #3c3c3d;
+      --dsw-alias-label-primary: #f9fafb;
+      --dsw-alias-label-secondary: #adb2b8;
+      --dsw-alias-label-tertiary: #81858c;
+      --dsw-alias-brand-primary: #f9fafb;
+      --dsw-alias-label-primary-foreground: #0f1115;
+    }
+
     @media (min-width: 769px) {
       .dsh-mobile-app-header,
       .dsh-mobile-backdrop,

--- a/lib/bridge-rpc.js
+++ b/lib/bridge-rpc.js
@@ -157,8 +157,8 @@ export function installBridgeRpc(ctx, { service, authManager, platformManager, l
           if (adminErr) return adminErr;
 
           // 未提供的字段保持 undefined 透传：服务端视为"保留现值"
-          const { serverUrl, accessToken } = payload;
-          await saveCustomTunnelConfig(serverUrl, accessToken);
+          const { serverUrl, accessToken, sseStreaming } = payload;
+          await saveCustomTunnelConfig(serverUrl, accessToken, sseStreaming);
           const status = await service.getStatus();
           return ok(status);
         }

--- a/lib/index.js
+++ b/lib/index.js
@@ -801,6 +801,7 @@ class BridgeService {
         configured: !!(this.customTunnelConfig?.serverUrl && this.customTunnelConfig?.accessToken),
         serverUrl: this.customTunnelConfig?.serverUrl ?? '',
         running: !!this.customTunnel?.connected,
+        sseStreaming: Boolean(this.customTunnelConfig?.sseStreaming),
         url: customUrl,
         rawUrl: baseCustomUrl,
         qr: customUrl
@@ -896,6 +897,7 @@ class BridgeService {
       accessToken,
       localPort: this.proxyPort,
       internalTunnelSecret: this.authManager?.internalTunnelSecret,
+      sseStreaming: Boolean(this.customTunnelConfig?.sseStreaming),
       onStateChange: (state) => {
         this.customTunnelState = state;
       },
@@ -1852,13 +1854,14 @@ function apply(ctx, config = {}) {
     telegram,
     platformManager,
     logger,
-    saveCustomTunnelConfig: async (serverUrl, accessToken) => {
+    saveCustomTunnelConfig: async (serverUrl, accessToken, sseStreaming) => {
       const stored = await updateConfig((current) => {
         const prev = service.customTunnelConfig ?? {};
         const next = { ...prev };
         // 与 saveCloudflaredConfig 同契约：undefined/掩码保留现值，空串清除
         if (serverUrl !== undefined) next.serverUrl = String(serverUrl).trim();
         if (accessToken !== undefined) next.accessToken = accessToken === '******' ? (prev.accessToken ?? '') : accessToken;
+        if (sseStreaming !== undefined) next.sseStreaming = Boolean(sseStreaming);
         current.customTunnel = next;
         return current;
       });

--- a/lib/index.js
+++ b/lib/index.js
@@ -514,7 +514,16 @@ class ProxyServer {
 
     // WebSocket upgrade 鉴权与代理
     this.server.on('upgrade', (req, socket, head) => {
-      const auth = this.authManager?.verifyRequest(req) ?? { authenticated: true };
+      // 自建隧道 WebSocket 升级：已有 internalTunnelSecret 认证，跳过 cookie 检查
+      // 仅限 WebSocket 升级请求——HTTP 请求仍需 cookie 认证
+      const _remote = req.socket?.remoteAddress || '';
+      const _isLoopback = (_remote === '127.0.0.1' || _remote === '::1' || _remote === '::ffff:127.0.0.1');
+      const _tunnelHdr = req.headers?.['x-dsh-internal-tunnel'];
+      const _isTunnelWs = Boolean(_isLoopback && _tunnelHdr && _tunnelHdr === this.authManager?.internalTunnelSecret);
+
+      const auth = _isTunnelWs
+        ? { authenticated: true, publicBypass: true }
+        : (this.authManager?.verifyRequest(req) ?? { authenticated: true });
       if (!auth.authenticated) {
         socket.write('HTTP/1.1 401 Unauthorized\r\nContent-Type: text/plain\r\n\r\nUnauthorized\r\n');
         socket.destroy();

--- a/lib/index.js
+++ b/lib/index.js
@@ -481,8 +481,12 @@ class ProxyServer {
                 }
                 out = Buffer.from(html, 'utf8');
               } else if (isSessionProjection) {
-                const { body, stripped } = stripSessionProjections(pathname, out);
-                if (stripped) out = body;
+                const { body, stripped } = stripSessionProjections(pathname, out, proxyRes.headers['content-encoding']);
+                if (stripped) {
+                  out = body;
+                  // 已修改 body，清除原始压缩编码标记
+                  delete outHeaders['content-encoding'];
+                }
               }
               // 缓冲改写过 body：必须去掉原始传输头，避免 content-length 与
               // transfer-encoding 并存导致客户端解析错误（HPE_INVALID_CONTENT_LENGTH）
@@ -514,8 +518,6 @@ class ProxyServer {
 
     // WebSocket upgrade 鉴权与代理
     this.server.on('upgrade', (req, socket, head) => {
-      // 与 HTTP 请求完全相同的标准鉴权流程：verifyRequest() 统一校验
-      // 隧道流量通过浏览器 Cookie (dsh_bridge_auth) 或 ?token= 认证，无任何 bypass
       const auth = this.authManager?.verifyRequest(req) ?? { authenticated: true };
       if (!auth.authenticated) {
         socket.write('HTTP/1.1 401 Unauthorized\r\nContent-Type: text/plain\r\n\r\nUnauthorized\r\n');

--- a/lib/index.js
+++ b/lib/index.js
@@ -514,16 +514,9 @@ class ProxyServer {
 
     // WebSocket upgrade 鉴权与代理
     this.server.on('upgrade', (req, socket, head) => {
-      // 自建隧道 WebSocket 升级：已有 internalTunnelSecret 认证，跳过 cookie 检查
-      // 仅限 WebSocket 升级请求——HTTP 请求仍需 cookie 认证
-      const _remote = req.socket?.remoteAddress || '';
-      const _isLoopback = (_remote === '127.0.0.1' || _remote === '::1' || _remote === '::ffff:127.0.0.1');
-      const _tunnelHdr = req.headers?.['x-dsh-internal-tunnel'];
-      const _isTunnelWs = Boolean(_isLoopback && _tunnelHdr && _tunnelHdr === this.authManager?.internalTunnelSecret);
-
-      const auth = _isTunnelWs
-        ? { authenticated: true, publicBypass: true }
-        : (this.authManager?.verifyRequest(req) ?? { authenticated: true });
+      // 与 HTTP 请求完全相同的标准鉴权流程：verifyRequest() 统一校验
+      // 隧道流量通过浏览器 Cookie (dsh_bridge_auth) 或 ?token= 认证，无任何 bypass
+      const auth = this.authManager?.verifyRequest(req) ?? { authenticated: true };
       if (!auth.authenticated) {
         socket.write('HTTP/1.1 401 Unauthorized\r\nContent-Type: text/plain\r\n\r\nUnauthorized\r\n');
         socket.destroy();

--- a/lib/session-strip.js
+++ b/lib/session-strip.js
@@ -9,6 +9,12 @@
 //   - tunnel-client.mjs（自建隧道）
 //   - index.js ProxyServer（局域网 / Cloudflare 隧道 / 外部隧道登记 —— 所有公网入口）
 // 命中失败（非 200 / 解析失败 / 结构不符）时原样返回，绝不破坏响应。
+//
+// DSH web 服务器默认开启 gzip 压缩（compression: gzip, level 1, threshold 1KB），
+// 所以 API 响应可能是 gzip 编码的。必须先解压才能 JSON.parse，否则解析失败，
+// catch {} 静默跳过剥离 → 完整 58MB+ 响应原样传输 → 隧道慢。
+
+import { gunzipSync } from 'node:zlib';
 
 const STRIP_PATHS = new Set(['/api/session.list', '/api/session.history']);
 
@@ -16,15 +22,19 @@ const STRIP_PATHS = new Set(['/api/session.list', '/api/session.history']);
  * 剥离 session.list / session.history 响应中的 contextHeaders 与 contextTimeline。
  * @param {string} pathname 请求路径（不含 query）
  * @param {Buffer} bodyBuf 原始响应体
- * @returns {{ body: Buffer, stripped: boolean }} stripped=true 表示发生了剥离（调用方需更新 content-length）
+ * @param {string} [contentEncoding] 响应的 content-encoding 头值（用于判断是否 gzip）
+ * @returns {{ body: Buffer, stripped: boolean }} stripped=true 表示发生了剥离（调用方需更新 content-length 和 content-encoding）
  */
-export function stripSessionProjections(pathname, bodyBuf) {
+export function stripSessionProjections(pathname, bodyBuf, contentEncoding) {
   const cleanPath = String(pathname || '').split('?')[0];
   if (!STRIP_PATHS.has(cleanPath) || !Buffer.isBuffer(bodyBuf)) {
     return { body: bodyBuf, stripped: false };
   }
   try {
-    const json = JSON.parse(bodyBuf.toString('utf8'));
+    // 如果 DSH 服务器 gzip 压缩了响应，先解压再解析
+    const isGzipped = String(contentEncoding ?? '').toLowerCase() === 'gzip';
+    const parseBuf = isGzipped ? gunzipSync(bodyBuf) : bodyBuf;
+    const json = JSON.parse(parseBuf.toString('utf8'));
     if (json?.result?.ok) {
       const v = json.result.value;
       let changed = false;
@@ -52,6 +62,6 @@ export function stripSessionProjections(pathname, bodyBuf) {
         return { body: Buffer.from(JSON.stringify(json), 'utf8'), stripped: true };
       }
     }
-  } catch { /* 解析失败则原样发送 */ }
+  } catch { /* 解析/解压失败则原样发送 */ }
   return { body: bodyBuf, stripped: false };
 }

--- a/lib/tunnel-client.mjs
+++ b/lib/tunnel-client.mjs
@@ -4,6 +4,7 @@ import { request as httpRequest } from 'node:http';
 import { connect as netConnect } from 'node:net';
 import { promisify } from 'node:util';
 import { gzip as gzipCallback } from 'node:zlib';
+import { randomBytes as cryptoRandomBytes } from 'node:crypto';
 import { stripSessionProjections } from './session-strip.js';
 
 const gzipAsync = promisify(gzipCallback);
@@ -207,6 +208,7 @@ export class CustomTunnelClient {
         res.on('data', (c) => {
           if (sseSent) return;
           chunks.push(c);
+          // 收到初始数据后立即发送（不等超时）
           if (chunks.length >= 2) {
             clearTimeout(sseTimer);
             sseSent = true;
@@ -282,17 +284,22 @@ export class CustomTunnelClient {
         let bodyBuf = Buffer.concat(chunks);
 
         // 剥离 session.list / session.history 的 contextHeaders 投影（无 UI 读取的大字段）
+        // 传入 content-encoding 以便 stripSessionProjections 先 gunzip 再解析
         if (res.statusCode === 200) {
-          const { body, stripped } = stripSessionProjections(path, bodyBuf);
+          const { body, stripped } = stripSessionProjections(path, bodyBuf, res.headers['content-encoding']);
           if (stripped) {
             bodyBuf = body;
+            // 已修改 body，清除原始压缩编码标记，让下方 gzip 逻辑重新压缩
+            delete respHeaders['content-encoding'];
             respHeaders['content-length'] = String(bodyBuf.length);
           }
         }
 
         // 大响应 gzip 压缩：异步执行，避免 gzipSync 卡住整个事件循环
         const respCt = String(res.headers['content-type'] ?? '').toLowerCase();
-        const alreadyEncoded = String(res.headers['content-encoding'] ?? '').toLowerCase();
+        // 注意：alreadyEncoded 从 respHeaders 读取（而非 res.headers），
+        // 因为上面的剥离逻辑可能已经删除了 respHeaders['content-encoding']
+        const alreadyEncoded = String(respHeaders['content-encoding'] ?? res.headers['content-encoding'] ?? '').toLowerCase();
         const compressible = COMPRESSIBLE_TYPES.some((t) => respCt.startsWith(t));
         if (bodyBuf.length > GZIP_THRESHOLD && compressible && !alreadyEncoded) {
           gzipAsync(bodyBuf).then((zipped) => {
@@ -341,9 +348,15 @@ export class CustomTunnelClient {
     let headerBuf = '';
     let upgraded = false;
 
+    // WebSocket 帧解析缓冲区 — 拦截 Ping (0x9) 自动回复 Pong (0xA)。
+    // DSH API Gateway 的 /api/remote.mux WebSocket 每 2s 发 Ping，连续 2 次没收到
+    // Pong 就 terminate。隧道用裸 TCP 转发，Pong 往返延迟可能超时，本地直接回复最可靠。
+    let wsFrameBuf = Buffer.alloc(0);
+
     sock.on('data', (chunk) => {
       if (upgraded) {
-        this._sendMessage({ type: 'ws-frame', wsId, data: chunk.toString('base64') });
+        wsFrameBuf = Buffer.concat([wsFrameBuf, chunk]);
+        wsFrameBuf = this._processWsFrames(wsId, wsFrameBuf, sock);
         return;
       }
       headerBuf += chunk.toString('binary');
@@ -392,6 +405,70 @@ export class CustomTunnelClient {
       this._sendMessage({ type: 'ws-close', wsId });
       this.localWsSockets.delete(wsId);
     });
+  }
+
+  // ── WebSocket 帧解析 ─────────────────────────────────────────────────────
+  // 在裸 TCP 层面解析 WebSocket 帧，拦截 Ping (0x9) 自动回复 Pong (0xA)，
+  // 其余帧原样转发。DSH API Gateway 每 2s 发 Ping，2 次没 Pong 就 terminate。
+  _processWsFrames(wsId, buf, sock) {
+    while (buf.length >= 2) {
+      const b0 = buf[0];
+      const b1 = buf[1];
+      const opcode = b0 & 0x0f;
+      const masked = b1 & 0x80;
+      let payloadLen = b1 & 0x7f;
+      let offset = 2;
+
+      if (payloadLen === 126) {
+        if (buf.length < 4) break;
+        payloadLen = buf.readUInt16BE(2);
+        offset = 4;
+      } else if (payloadLen === 127) {
+        if (buf.length < 10) break;
+        payloadLen = Number(buf.readBigUInt64BE(2));
+        offset = 10;
+      }
+      if (masked) offset += 4;
+      if (buf.length < offset + payloadLen) break;
+
+      const frameEnd = offset + payloadLen;
+      const frameBytes = buf.subarray(0, frameEnd);
+
+      if (opcode === 0x9) {
+        // Ping → 自动回复 Pong（同 payload，必须 mask，因为这是 client→server 方向）
+        // WebSocket 协议规定客户端→服务端的帧必须加 mask，否则服务端 ws 库会判定
+        // 协议错误（1002）并关闭连接。
+        const payload = buf.subarray(offset, frameEnd);
+        const mask = cryptoRandomBytes(4);
+        const maskedPayload = Buffer.alloc(payload.length);
+        for (let i = 0; i < payload.length; i++) {
+          maskedPayload[i] = payload[i] ^ mask[i % 4];
+        }
+        if (payload.length < 126) {
+          const hdr = Buffer.alloc(6);
+          hdr[0] = 0x8a; // fin + opcode 0xA (pong)
+          hdr[1] = 0x80 | payload.length; // masked + length
+          mask.copy(hdr, 2);
+          sock.write(Buffer.concat([hdr, maskedPayload]));
+        } else if (payload.length < 65536) {
+          const hdr = Buffer.alloc(8);
+          hdr[0] = 0x8a; hdr[1] = 0x80 | 126;
+          hdr.writeUInt16BE(payload.length, 2);
+          mask.copy(hdr, 4);
+          sock.write(Buffer.concat([hdr, maskedPayload]));
+        } else {
+          const hdr = Buffer.alloc(14);
+          hdr[0] = 0x8a; hdr[1] = 0x80 | 127;
+          hdr.writeBigUInt64BE(BigInt(payload.length), 2);
+          mask.copy(hdr, 10);
+          sock.write(Buffer.concat([hdr, maskedPayload]));
+        }
+      } else {
+        this._sendMessage({ type: 'ws-frame', wsId, data: frameBytes.toString('base64') });
+      }
+      buf = buf.subarray(frameEnd);
+    }
+    return buf;
   }
 
   _handleWsFrame(msg) {

--- a/lib/tunnel-client.mjs
+++ b/lib/tunnel-client.mjs
@@ -351,6 +351,7 @@ export class CustomTunnelClient {
       if (sep === -1) return;
 
       upgraded = true;
+      const statusLine = headerBuf.slice(0, headerBuf.indexOf('\r\n'));
       const replyHeaders = {};
       const headerLines = headerBuf.slice(0, sep).split('\r\n');
       for (let i = 1; i < headerLines.length; i++) {
@@ -360,7 +361,20 @@ export class CustomTunnelClient {
             headerLines[i].slice(ci + 1).trim();
         }
       }
-      this._sendMessage({ type: 'ws-accept', wsId, replyHeaders });
+
+      // 解析状态码，传递给服务端以便正确转发（非 101 时浏览器能看到真实错误）
+      const statusMatch = /^HTTP\/1\.\d\s+(\d+)\s*(.*)/.exec(statusLine);
+      const statusCode = statusMatch ? parseInt(statusMatch[1], 10) : 101;
+      const statusMessage = statusMatch ? statusMatch[2] : '';
+
+      if (statusCode === 101) {
+        this._sendMessage({ type: 'ws-accept', wsId, statusCode, replyHeaders });
+      } else {
+        // 非 101 响应：转发状态码和头，让浏览器看到真实错误（如 401）
+        this._sendMessage({ type: 'ws-accept', wsId, statusCode, statusMessage, replyHeaders });
+        sock.destroy();
+        return;
+      }
 
       // 握手后紧跟的帧数据
       const rest = headerBuf.slice(sep + 4);

--- a/lib/tunnel-client.mjs
+++ b/lib/tunnel-client.mjs
@@ -22,7 +22,7 @@ const GZIP_THRESHOLD = 102400; // 100KB
 const COMPRESSIBLE_TYPES = ['text/', 'application/json', 'application/javascript', 'application/xml'];
 
 export class CustomTunnelClient {
-  constructor({ serverUrl, accessToken, localPort, internalTunnelSecret, signal, onStateChange, logger }) {
+  constructor({ serverUrl, accessToken, localPort, internalTunnelSecret, signal, onStateChange, logger, sseStreaming = false }) {
     this.serverUrl = serverUrl;
     this.accessToken = accessToken;
     this.localPort = localPort;
@@ -30,6 +30,7 @@ export class CustomTunnelClient {
     this.signal = signal;
     this.onStateChange = onStateChange;
     this.logger = logger;
+    this.sseStreaming = sseStreaming;
     this.ws = null;
     this.publicUrl = null;
     this.connected = false;
@@ -161,8 +162,33 @@ export class CustomTunnelClient {
       const chunks = [];
 
       if (isSSE) {
-        // SSE 流式响应：隧道协议不支持流式，收集初始数据后立即返回
-        // 避免 SSE 永不 end 导致隧道服务器超时返回 504
+        if (this.sseStreaming) {
+          // ── 流式模式（需服务端支持 response-start/chunk/end 协议）──
+          // 逐 chunk 转发，SSE 长连接持续保持，浏览器端不会断连重连
+          const respHeaders = Object.fromEntries(
+            Object.entries(res.headers).filter(([k]) => !SKIP.has(k.toLowerCase()))
+          );
+          this._sendMessage({
+            type: 'response-start', requestId,
+            statusCode: res.statusCode, headers: respHeaders,
+          });
+          res.on('data', (c) => {
+            this._sendMessage({
+              type: 'response-chunk', requestId,
+              body: c.toString('base64'),
+            });
+          });
+          res.on('error', () => {
+            this._sendMessage({ type: 'response-end', requestId });
+          });
+          res.on('end', () => {
+            this._sendMessage({ type: 'response-end', requestId });
+          });
+          return;
+        }
+
+        // ── 截断模式（默认，兼容老服务端）──
+        // 收集初始数据后立即返回，避免 SSE 永不 end 导致隧道服务器超时 504
         let sseSent = false;
         const sseTimer = setTimeout(() => {
           if (sseSent) return;
@@ -181,7 +207,6 @@ export class CustomTunnelClient {
         res.on('data', (c) => {
           if (sseSent) return;
           chunks.push(c);
-          // 收到初始数据后立即发送（不等超时）
           if (chunks.length >= 2) {
             clearTimeout(sseTimer);
             sseSent = true;

--- a/scripts/install-tunnel-server.sh
+++ b/scripts/install-tunnel-server.sh
@@ -314,7 +314,7 @@ wss.on('connection', (ws, req) => {
     try {
       const msg = JSON.parse(raw.toString());
 
-      // HTTP 响应
+      // HTTP 响应（非流式：一次性返回完整 body）
       if (msg.type === 'response') {
         const p = pending.get(msg.requestId);
         if (!p) return;
@@ -326,6 +326,41 @@ wss.on('connection', (ws, req) => {
         );
         p.res.writeHead(msg.statusCode ?? 502, headers);
         p.res.end(Buffer.from(msg.body || '', 'base64'));
+        return;
+      }
+
+      // ── SSE 流式响应（response-start / response-chunk / response-end）──
+      // 向后兼容：老客户端不发这三类消息，走上面的 response 路径不受影响.
+
+      // 流式响应开始：写头，清除超时（SSE 长连接不设超时）
+      if (msg.type === 'response-start') {
+        const p = pending.get(msg.requestId);
+        if (!p) return;
+        clearTimeout(p.timer);
+        p.timer = null;
+        const HOP_BY_HOP = new Set(['transfer-encoding', 'connection', 'keep-alive', 'te', 'trailer', 'upgrade']);
+        const headers = Object.fromEntries(
+          Object.entries(msg.headers ?? {}).filter(([k]) => !HOP_BY_HOP.has(k.toLowerCase()))
+        );
+        p.res.writeHead(msg.statusCode ?? 200, headers);
+        return;
+      }
+
+      // 流式响应 chunk：逐块写入
+      if (msg.type === 'response-chunk') {
+        const p = pending.get(msg.requestId);
+        if (!p) return;
+        p.res.write(Buffer.from(msg.body || '', 'base64'));
+        return;
+      }
+
+      // 流式响应结束：end 并清理
+      if (msg.type === 'response-end') {
+        const p = pending.get(msg.requestId);
+        if (!p) return;
+        if (p.timer) clearTimeout(p.timer);
+        pending.delete(msg.requestId);
+        try { p.res.end(); } catch {}
         return;
       }
 
@@ -379,6 +414,12 @@ wss.on('connection', (ws, req) => {
     tunnelClients.delete(id);
     // 清理所有挂在这个 client 上的 browser socket
     for (const [wsId, sock] of browserWsSockets) { sock.destroy(); browserWsSockets.delete(wsId); }
+    // 清理所有流式/待响应的 HTTP 响应
+    for (const [requestId, p] of pending) {
+      if (p.timer) clearTimeout(p.timer);
+      try { p.res.end(); } catch {}
+    }
+    pending.clear();
     console.log(`[dsh-tunnel] client disconnected  id=${id}  code=${code}  remaining=${tunnelClients.size}`);
   });
   ws.on('error', err => console.error(`[dsh-tunnel] client error id=${id}: ${err.message}`));

--- a/scripts/install-tunnel-server.sh
+++ b/scripts/install-tunnel-server.sh
@@ -366,29 +366,37 @@ wss.on('connection', (ws, req) => {
 
       // WebSocket 握手成功，完成升级并接管 socket
       if (msg.type === 'ws-accept') {
-        const { wsId, replyHeaders } = msg;
+        const { wsId, replyHeaders, statusCode, statusMessage } = msg;
         const upgrade = pendingWsUpgrades.get(wsId);
         if (!upgrade) return;
         pendingWsUpgrades.delete(wsId);
 
         const { socket } = upgrade;
-        // 回写 101 Switching Protocols
-        const lines = ['HTTP/1.1 101 Switching Protocols'];
+        // 使用隧道客户端传来的实际状态码（非 101 时浏览器能看到真实错误）
+        const code = statusCode || 101;
+        const reason = statusMessage || (code === 101 ? 'Switching Protocols' : '');
+        const lines = [`HTTP/1.1 ${code} ${reason}`.trim()];
         for (const [k, v] of Object.entries(replyHeaders ?? {})) lines.push(`${k}: ${v}`);
         lines.push('', '');
         socket.write(lines.join('\r\n'));
-        browserWsSockets.set(wsId, socket);
 
-        socket.on('data', chunk => {
-          if (ws.readyState === ws.OPEN) {
-            ws.send(JSON.stringify({ type: 'ws-frame', wsId, data: chunk.toString('base64') }));
-          }
-        });
-        socket.on('close', () => {
-          if (ws.readyState === ws.OPEN) ws.send(JSON.stringify({ type: 'ws-close', wsId }));
-          browserWsSockets.delete(wsId);
-        });
-        socket.on('error', () => socket.destroy());
+        // 仅 101 时才接管为 WebSocket 隧道
+        if (code === 101) {
+          browserWsSockets.set(wsId, socket);
+          socket.on('data', chunk => {
+            if (ws.readyState === ws.OPEN) {
+              ws.send(JSON.stringify({ type: 'ws-frame', wsId, data: chunk.toString('base64') }));
+            }
+          });
+          socket.on('close', () => {
+            if (ws.readyState === ws.OPEN) ws.send(JSON.stringify({ type: 'ws-close', wsId }));
+            browserWsSockets.delete(wsId);
+          });
+          socket.on('error', () => socket.destroy());
+        } else {
+          // 非 101：结束连接，不接管为 WebSocket
+          socket.end();
+        }
         return;
       }
 


### PR DESCRIPTION
## 问题

自建隧道（WebSocket 反向隧道 + Token 认证）此前会把上游响应**整体缓冲后一次性返回**。这对 SSE 长连接是致命的：

- 隧道服务器在浏览器收到第一个事件之前就超时（504）；
- 浏览器端断连重连，循环往复；
- SSE 流式场景（如 dsh 的流式输出）在自建隧道下完全不可用。

## 修复

### 1. SSE 流式转发

在自建隧道配置上新增一个**可选开关**「SSE 流式转发」。当服务端支持 `response-start` / `response-chunk` / `response-end` 协议时，隧道客户端逐 chunk 转发，SSE 长连接持续保持，浏览器端不再断连重连。当服务端不支持（或开关关闭）时，沿用原有的**截断模式**（收集初始数据后立即返回），保持向后兼容。

### 2. gzip-aware session projection stripping

DSH web 服务器默认开启 gzip 压缩（`compression: gzip, level 1, threshold 1KB`），API 响应可能是 gzip 编码的。`stripSessionProjections` 之前直接 `JSON.parse` gzip 数据 → 解析失败 → `catch {}` 静默跳过剥离 → 完整 58MB+ 响应原样传输 → 隧道慢。

修复：传入 `content-encoding` 参数，先 `gunzipSync` 解压再 `JSON.parse`。剥离后清除 `content-encoding` 头，让下方 gzip 逻辑重新压缩。

### 3. WebSocket Ping/Pong keepalive

DSH API Gateway 的 `/api/remote.mux` WebSocket 每 2s 发 Ping，连续 2 次没收到 Pong 就 terminate 连接。隧道用裸 TCP 转发，Pong 往返延迟可能超时。

修复：在 `tunnel-client.mjs` 的 `_processWsFrames` 方法中，在裸 TCP 层面解析 WebSocket 帧，拦截 Ping (0x9) 自动回复 Pong (0xA)。Pong 帧加 4 字节随机 mask（RFC 6455 要求 client→server 方向帧必须 masked），其余帧原样转发。

### 4. 深色主题适配：目录浏览器弹窗

目录浏览器弹窗（`showRemoteWorkspaceDialog`）在深色主题下颜色显示不正确：

- 按钮背景使用 `--dsw-alias-brand-primary`，该变量在深色模式下值为 `#f9fafb`（白色），导致按钮背景变白。改用 `--dsw-static-blue-600`（`#2563eb`），该静态蓝色在浅色和深色模式下值相同。
- DSH 主题系统未定义 `--dsw-alias-state-*-bg` / `state-*-border` / `state-*-primary` 系列变量，弹窗的警告/错误/成功/信息提示在深色模式下回退到浅色值。在 `MOBILE_STYLES_CSS` 中补充深色模式值。
- 弹窗内元素的 CSS 变量可能未正确从 `body[data-ds-dark-theme]` 继承，添加直接覆盖规则确保弹窗内所有元素使用深色值。

### 5. 移除 WebSocket auth bypass

WebSocket upgrade 鉴权与 HTTP 请求使用完全相同的 `verifyRequest()` 标准流程，无任何 bypass。

## 变更文件

| 文件 | 说明 |
|---|---|
| `lib/tunnel-client.mjs` | SSE 流式转发 + gzip-aware 剥离 + WebSocket Ping/Pong keepalive |
| `lib/session-strip.js` | 新增 `contentEncoding` 参数 + `gunzipSync` |
| `lib/index.js` | ProxyServer 同步 gzip-aware 剥离 + 移除 WebSocket auth bypass |
| `lib/bridge-rpc.js` | RPC handler 传递 `sseStreaming` |
| `client/client.js` | SSE 流式转发 UI + 深色主题适配 |
| `client/index.js` | 深色主题适配（源文件） |
| `client/mobile-styles.js` | 深色模式 CSS 变量补充 |

## 兼容性

- **SSE 默认关闭**：老配置和老服务端行为不变（走截断模式）。
- **gzip 剥离向后兼容**：`contentEncoding` 参数可选，不传时行为与之前一致。
- **Ping/Pong 透明**：非 Ping 帧原样转发，不影响正常 WebSocket 通信。
- 已在本地 `dsh-bridge@2.10.3` 验证全部功能。

### 类型

- [x] ✨ 新功能（SSE 流式转发）
- [x] 🐛 Bug 修复（gzip 剥离、Ping/Pong、深色主题）