### PR TITLE
feat(auth): 登录 Session 持久化，宿主（dsh web）重启后已登录设备免重输访问密码

### DIFF
--- a/lib/auth/manager.js
+++ b/lib/auth/manager.js
@@ -26,22 +26,28 @@ const PBKDF2_PREFIX = 'pbkdf2-sha256$'
 // sessionToken 与 secretToken 同级机密（48 位随机 hex），同目录存储不扩大暴露面。
 // 改密码 / 切模式 / 重新生成 token 时的 sessions.clear() 会同步清空文件（吊销语义保持）；
 // 文件缺失或损坏时安全降级为空 Map（等价于旧行为：重新登录一次）。
-const SESSIONS_FILE = join(
+// 路径可通过构造参数 sessionsFile 注入（测试传临时目录，避免读写真实环境）。
+const DEFAULT_SESSIONS_FILE = join(
   process.env.DSH_HOME ?? join(homedir(), '.dsh'),
   'dsh-bridge', 'sessions.json'
 )
 
 class PersistentSessionMap extends Map {
+  /** @param {string} file 会话落盘文件路径 */
+  constructor(file) {
+    super()
+    this._file = file
+  }
   _flush() {
     try {
-      mkdirSync(dirname(SESSIONS_FILE), { recursive: true })
-      writeFileSync(SESSIONS_FILE, JSON.stringify([...this.entries()]), { mode: 0o600 })
+      mkdirSync(dirname(this._file), { recursive: true })
+      writeFileSync(this._file, JSON.stringify([...this.entries()]), { mode: 0o600 })
     } catch { /* 落盘失败降级为纯内存语义，不阻断认证流程 */ }
   }
-  static load() {
-    const m = new PersistentSessionMap()
+  static load(file) {
+    const m = new PersistentSessionMap(file)
     try {
-      const arr = JSON.parse(readFileSync(SESSIONS_FILE, 'utf8'))
+      const arr = JSON.parse(readFileSync(file, 'utf8'))
       if (Array.isArray(arr)) {
         const now = Date.now()
         for (const [k, v] of arr) {
@@ -71,9 +77,10 @@ export class AuthManager {
    * @param {boolean} [opts.config.allowLoopback=true]
    * @param {boolean} [opts.config.adminProtection=true] 管理保护独立开关：关闭后管理操作免 adminToken
    * @param {(patch: object) => Promise<void>|void} [opts.onPersist]
+   * @param {string} [opts.sessionsFile] 登录会话持久化文件路径（默认 ~/.dsh/dsh-bridge/sessions.json；测试注入临时目录）
    * @param {object} [opts.logger]
    */
-  constructor({ config = {}, onPersist, logger = console } = {}) {
+  constructor({ config = {}, onPersist, sessionsFile, logger = console } = {}) {
     this.logger = logger
     this.onPersist = onPersist
 
@@ -93,8 +100,8 @@ export class AuthManager {
     this.internalTunnelSecret = randomBytes(24).toString('hex')
 
     // Session 存储与重启恢复：sessionToken -> { createdAt, expiresAt }
-    // 持久化到 sessions.json，宿主（dsh web）重启后已登录设备免重输访问密码
-    this.sessions = PersistentSessionMap.load()
+    // 持久化到 sessions.json（路径可经 sessionsFile 注入），宿主（dsh web）重启后已登录设备免重输访问密码
+    this.sessions = PersistentSessionMap.load(sessionsFile ?? DEFAULT_SESSIONS_FILE)
     // 管理员解锁 Session 内存存储：adminToken -> { createdAt, expiresAt }
     this.adminSessions = new Map()
     // 防暴力破解：ip -> { failedCount, lockUntil }

--- a/lib/auth/manager.js
+++ b/lib/auth/manager.js
@@ -3,6 +3,9 @@
 
 import { randomBytes, pbkdf2 as pbkdf2Callback, timingSafeEqual } from 'node:crypto'
 import { promisify } from 'node:util'
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join, dirname } from 'node:path'
 
 const pbkdf2Async = promisify(pbkdf2Callback)
 
@@ -17,6 +20,44 @@ const PBKDF2_ITERATIONS = 600000
 const LEGACY_PBKDF2_ITERATIONS = 10000
 const PBKDF2_KEYLEN = 32
 const PBKDF2_PREFIX = 'pbkdf2-sha256$'
+
+// 登录 Session 持久化：宿主（dsh web 进程）重启后，已登录设备免重输访问密码。
+// 落盘文件与 config.json 同目录（~/.dsh/dsh-bridge/sessions.json，权限 600）；
+// sessionToken 与 secretToken 同级机密（48 位随机 hex），同目录存储不扩大暴露面。
+// 改密码 / 切模式 / 重新生成 token 时的 sessions.clear() 会同步清空文件（吊销语义保持）；
+// 文件缺失或损坏时安全降级为空 Map（等价于旧行为：重新登录一次）。
+const SESSIONS_FILE = join(
+  process.env.DSH_HOME ?? join(homedir(), '.dsh'),
+  'dsh-bridge', 'sessions.json'
+)
+
+class PersistentSessionMap extends Map {
+  _flush() {
+    try {
+      mkdirSync(dirname(SESSIONS_FILE), { recursive: true })
+      writeFileSync(SESSIONS_FILE, JSON.stringify([...this.entries()]), { mode: 0o600 })
+    } catch { /* 落盘失败降级为纯内存语义，不阻断认证流程 */ }
+  }
+  static load() {
+    const m = new PersistentSessionMap()
+    try {
+      const arr = JSON.parse(readFileSync(SESSIONS_FILE, 'utf8'))
+      if (Array.isArray(arr)) {
+        const now = Date.now()
+        for (const [k, v] of arr) {
+          // 只恢复结构合法且未过期的会话
+          if (typeof k === 'string' && v && Number.isFinite(v.expiresAt) && v.expiresAt > now) {
+            Map.prototype.set.call(m, k, { createdAt: Number(v.createdAt) || 0, expiresAt: Number(v.expiresAt) })
+          }
+        }
+      }
+    } catch { /* 文件缺失/损坏：降级为空 */ }
+    return m
+  }
+  set(k, v) { super.set(k, v); this._flush(); return this }
+  delete(k) { const r = super.delete(k); if (r) this._flush(); return r }
+  clear() { super.clear(); this._flush() }
+}
 
 export class AuthManager {
   /**
@@ -51,8 +92,9 @@ export class AuthManager {
     // 内部隧道专用鉴权密钥（内存生成，用于辨别本地自建隧道转发流量与真实本机访问）
     this.internalTunnelSecret = randomBytes(24).toString('hex')
 
-    // Session 内存存储：sessionToken -> { createdAt, expiresAt }
-    this.sessions = new Map()
+    // Session 存储与重启恢复：sessionToken -> { createdAt, expiresAt }
+    // 持久化到 sessions.json，宿主（dsh web）重启后已登录设备免重输访问密码
+    this.sessions = PersistentSessionMap.load()
     // 管理员解锁 Session 内存存储：adminToken -> { createdAt, expiresAt }
     this.adminSessions = new Map()
     // 防暴力破解：ip -> { failedCount, lockUntil }
@@ -540,7 +582,8 @@ export class AuthManager {
 
   dispose() {
     clearInterval(this._cleanupTimer)
-    this.sessions.clear()
+    // 不清空 sessions：进程退出时内存随进程自然消失；
+    // 若此处 clear() 会把持久化文件一并清空，宿主重启后已登录设备仍会全部丢失
     this.rateLimits.clear()
   }
 }

--- a/test/auth-manager.test.mjs
+++ b/test/auth-manager.test.mjs
@@ -1,11 +1,15 @@
 // test/auth-manager.test.mjs
 import test from 'node:test'
 import assert from 'node:assert/strict'
+import { readFileSync, writeFileSync, mkdirSync, mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, dirname } from 'node:path'
 import { AuthManager } from '../lib/auth/manager.js'
 import { renderLoginPage } from '../lib/auth/login-template.js'
+import { makeSessionsFile } from './helpers.mjs'
 
 test('AuthManager initializes and generates default secretToken', () => {
-  const auth = new AuthManager()
+  const auth = new AuthManager({ sessionsFile: makeSessionsFile() })
   assert.equal(auth.enabled, false)
   assert.equal(auth.mode, 'token_and_password')
   assert.ok(auth.secretToken.startsWith('dsh_'))
@@ -15,7 +19,7 @@ test('AuthManager initializes and generates default secretToken', () => {
 
 test('AuthManager setPassword hashes with salt and verifies correctly', async () => {
   const persisted = []
-  const auth = new AuthManager({
+  const auth = new AuthManager({ sessionsFile: makeSessionsFile(),
     onPersist: (p) => persisted.push(p),
   })
 
@@ -42,7 +46,7 @@ test('AuthManager setPassword hashes with salt and verifies correctly', async ()
 
 test('AuthManager transparently upgrades legacy (10k) password hashes on login', async () => {
   const persisted = []
-  const auth = new AuthManager({
+  const auth = new AuthManager({ sessionsFile: makeSessionsFile(),
     onPersist: (p) => persisted.push(p),
   })
 
@@ -69,7 +73,7 @@ test('AuthManager transparently upgrades legacy (10k) password hashes on login',
 })
 
 test('AuthManager rate limits and locks out IP after 5 consecutive failures', async () => {
-  const auth = new AuthManager()
+  const auth = new AuthManager({ sessionsFile: makeSessionsFile() })
   await auth.setPassword('correct-pwd')
 
   const testIp = '10.0.0.99'
@@ -95,7 +99,7 @@ test('AuthManager rate limits and locks out IP after 5 consecutive failures', as
 })
 
 test('AuthManager session lifecycle: create, validate, and revoke', () => {
-  const auth = new AuthManager()
+  const auth = new AuthManager({ sessionsFile: makeSessionsFile() })
   const token = auth.createSession(5000)
   assert.ok(token)
   assert.equal(auth.validateSession(token), true)
@@ -107,7 +111,7 @@ test('AuthManager session lifecycle: create, validate, and revoke', () => {
 })
 
 test('AuthManager verifyRequest handles bypass, loopback, token, and cookie', () => {
-  const auth = new AuthManager({
+  const auth = new AuthManager({ sessionsFile: makeSessionsFile(),
     config: {
       enabled: true,
       mode: 'token_and_password',
@@ -173,7 +177,7 @@ test('renderLoginPage returns valid standalone HTML with DSH styling', () => {
 })
 
 test('AuthManager handles adminPolicy and remote admin unlocking', async () => {
-  const auth = new AuthManager({
+  const auth = new AuthManager({ sessionsFile: makeSessionsFile(),
     config: {
       enabled: true,
       adminPolicy: 'password_unlock',
@@ -210,7 +214,7 @@ test('AuthManager handles adminPolicy and remote admin unlocking', async () => {
 
 
 test('v2.10.5: password_only 模式 + 未设密码时 verifyPassword 放行（防自我锁死）', async () => {
-  const auth = new AuthManager({
+  const auth = new AuthManager({ sessionsFile: makeSessionsFile(),
     config: { enabled: true, mode: 'password_only' }, // 无密码
   })
   try {
@@ -224,7 +228,7 @@ test('v2.10.5: password_only 模式 + 未设密码时 verifyPassword 放行（�
 })
 
 test('v2.10.5: password_only 模式 + 已设密码时错误密码被拒绝（真实门禁生效）', async () => {
-  const auth = new AuthManager({ config: { enabled: true, mode: 'password_only' } })
+  const auth = new AuthManager({ sessionsFile: makeSessionsFile(), config: { enabled: true, mode: 'password_only' } })
   try {
     await auth.setPassword('real-pass-1')
     const wrong = await auth.verifyPassword('wrong-pass', '192.168.1.51')
@@ -234,4 +238,92 @@ test('v2.10.5: password_only 模式 + 已设密码时错误密码被拒绝（真
   } finally {
     auth.dispose()
   }
+})
+
+// ---- 登录 Session 持久化（宿主重启后已登录设备免重输访问密码）----
+
+test('session persistence: createSession 落盘，新实例（模拟宿主重启）恢复后仍有效', () => {
+  const sessionsFile = makeSessionsFile()
+  const auth = new AuthManager({ sessionsFile })
+  const token = auth.createSession()
+  auth.dispose()
+
+  // 落盘文件包含该会话
+  const raw = readFileSync(sessionsFile, 'utf8')
+  assert.ok(raw.includes(token), '会话必须写入落盘文件')
+
+  // 新实例同路径恢复——等价于 dsh web 宿主进程重启后 AuthManager 重新构造
+  const reborn = new AuthManager({ sessionsFile })
+  assert.equal(reborn.validateSession(token), true, '重启后已登录会话必须仍然有效')
+  assert.equal(reborn.validateSession('not-a-real-token'), false)
+  reborn.dispose()
+})
+
+test('session persistence: 改密码吊销全部会话并清空落盘文件，重启后仍拒绝', async () => {
+  const sessionsFile = makeSessionsFile()
+  const auth = new AuthManager({ sessionsFile })
+  const token = auth.createSession()
+  await auth.setPassword('brand-new-pass')
+  assert.equal(auth.validateSession(token), false, '改密码后本实例会话全部吊销')
+
+  const entries = JSON.parse(readFileSync(sessionsFile, 'utf8'))
+  assert.equal(entries.length, 0, '吊销必须同步清空落盘文件')
+
+  const reborn = new AuthManager({ sessionsFile })
+  assert.equal(reborn.validateSession(token), false, '重启后旧会话仍被拒绝')
+  reborn.dispose()
+})
+
+test('session persistence: 已过期的会话在恢复时被过滤', () => {
+  const sessionsFile = makeSessionsFile()
+  mkdirSync(dirname(sessionsFile), { recursive: true })
+  // 手写一条已过期会话 + 一条有效会话
+  const now = Date.now()
+  writeFileSync(sessionsFile, JSON.stringify([
+    ['expiredtoken', { createdAt: 1, expiresAt: now - 1000 }],
+    ['livetoken000', { createdAt: now, expiresAt: now + 60_000 }],
+  ]))
+
+  const auth = new AuthManager({ sessionsFile })
+  assert.equal(auth.validateSession('expiredtoken'), false, '过期会话不得恢复')
+  assert.equal(auth.validateSession('livetoken000'), true, '未过期会话正常恢复')
+  auth.dispose()
+})
+
+test('session persistence: 落盘文件损坏时安全降级为空（不抛异常）', () => {
+  const sessionsFile = makeSessionsFile()
+  mkdirSync(dirname(sessionsFile), { recursive: true })
+  writeFileSync(sessionsFile, '{not valid json!!!')
+
+  const auth = new AuthManager({ sessionsFile }) // 不应抛异常
+  const token = auth.createSession()
+  assert.equal(auth.validateSession(token), true, '降级后新登录正常（纯内存语义）')
+  auth.dispose()
+})
+
+test('session persistence: dispose 不清空落盘文件（宿主重启保活的关键）', () => {
+  const sessionsFile = makeSessionsFile()
+  const auth = new AuthManager({ sessionsFile })
+  const token = auth.createSession()
+  auth.dispose() // 宿主退出时 cleanup 调 dispose——此处不得清空持久化文件
+
+  const entries = JSON.parse(readFileSync(sessionsFile, 'utf8'))
+  assert.equal(entries.length, 1, 'dispose 后落盘文件必须保留（否则重启保活失效）')
+
+  const reborn = new AuthManager({ sessionsFile })
+  assert.equal(reborn.validateSession(token), true)
+  reborn.dispose()
+})
+
+test('session persistence: 落盘失败降级为纯内存语义（不阻断认证流程）', () => {
+  // 路径中段是一个普通文件：mkdirSync 必然失败（ENOTDIR），模拟不可写环境
+  const dir = mkdtempSync(join(tmpdir(), 'dsh-bridge-ro-'))
+  const blocker = join(dir, 'blocker')
+  writeFileSync(blocker, 'x')
+  const sessionsFile = join(blocker, 'sub', 'sessions.json')
+
+  const auth = new AuthManager({ sessionsFile }) // 不应抛异常
+  const token = auth.createSession()
+  assert.equal(auth.validateSession(token), true, '写盘失败不影响内存会话生命周期')
+  auth.dispose()
 })

--- a/test/enhanced-features.test.mjs
+++ b/test/enhanced-features.test.mjs
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import { BridgeService, selectLanIPv4 } from '../lib/index.js';
 import { ConversationBridge } from '../lib/platform/conversation-bridge.js';
 import { AuthManager } from '../lib/auth/manager.js';
+import { makeSessionsFile } from './helpers.mjs'
 
 test('ConversationBridge /rename command renames active session', async () => {
   const sentTexts = [];
@@ -111,7 +112,7 @@ test('BridgeService diagnoseNetwork runs diagnostics', async () => {
 });
 
 test('AuthManager and backup integration', async () => {
-  const auth = new AuthManager({
+  const auth = new AuthManager({ sessionsFile: makeSessionsFile(),
     logger: { info: () => {}, warn: () => {}, error: () => {} },
   });
 

--- a/test/helpers.mjs
+++ b/test/helpers.mjs
@@ -1,0 +1,14 @@
+// test/helpers.mjs —— 测试共用工具
+import { mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+/**
+ * 生成每个用例独立的登录会话落盘路径（临时目录）。
+ * AuthManager 的登录 Session 会持久化到磁盘；测试必须注入临时路径，
+ * 避免读写真实环境（~/.dsh/dsh-bridge/sessions.json）——
+ * 否则用例间相互污染，改密码吊销类用例还可能误清真实设备已登录的 session。
+ */
+export function makeSessionsFile() {
+  return join(mkdtempSync(join(tmpdir(), 'dsh-bridge-test-')), 'sessions.json')
+}

--- a/test/phase2-fixes.test.mjs
+++ b/test/phase2-fixes.test.mjs
@@ -2,6 +2,7 @@
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
 import { AuthManager } from '../lib/auth/manager.js'
+import { makeSessionsFile } from './helpers.mjs'
 
 // 并发读-改-写不得丢失更新：两个平台同时持久化，两份改动都必须落盘
 test('AuthManager 并发 persist 序列化且互不覆盖', async () => {
@@ -35,7 +36,7 @@ test('AuthManager 并发 persist 序列化且互不覆盖', async () => {
 
 // 管理解锁防爆破：5 次失败锁定，正确密码在锁定期内也被拒绝
 test('unlockAdmin 失败 5 次后锁定 60 秒（T2.8 回归）', async () => {
-  const auth = new AuthManager({
+  const auth = new AuthManager({ sessionsFile: makeSessionsFile(),
     config: { adminPasswordHash: '', adminPasswordSalt: '' },
     onPersist: async () => {},
   })
@@ -57,7 +58,7 @@ test('unlockAdmin 失败 5 次后锁定 60 秒（T2.8 回归）', async () => {
 })
 
 test('unlockAdmin 未设任何密码时直接放行（既有行为保持）', async () => {
-  const auth = new AuthManager({ config: {}, onPersist: async () => {} })
+  const auth = new AuthManager({ sessionsFile: makeSessionsFile(), config: {}, onPersist: async () => {} })
   const res = await auth.unlockAdmin('anything')
   assert.equal(res.ok, true)
   assert.ok(res.adminToken)

--- a/test/proxy-auth.test.mjs
+++ b/test/proxy-auth.test.mjs
@@ -4,6 +4,7 @@ import assert from 'node:assert/strict'
 import { createServer, request as httpRequest } from 'node:http'
 import { ProxyServer } from '../lib/index.js'
 import { AuthManager } from '../lib/auth/manager.js'
+import { makeSessionsFile } from './helpers.mjs'
 
 function doRequest(options, postBody) {
   return new Promise((resolve, reject) => {
@@ -41,7 +42,7 @@ test('ProxyServer end-to-end authentication: login, token redirect, and cookie p
   const backendPort = backend.address().port
 
   // 2. AuthManager with custom password & token
-  const authManager = new AuthManager({
+  const authManager = new AuthManager({ sessionsFile: makeSessionsFile(),
     config: {
       enabled: true,
       mode: 'token_and_password',
@@ -191,7 +192,7 @@ test('ProxyServer end-to-end authentication: login, token redirect, and cookie p
 })
 
 test('issue #28 regression: DSH native origin (dshPort) can read loopback-token cross-origin', async () => {
-  const authManager = new AuthManager({
+  const authManager = new AuthManager({ sessionsFile: makeSessionsFile(),
     config: { enabled: true, mode: 'token_and_password', allowLoopback: true },
     logger: { info: () => {}, warn: () => {}, error: () => {} },
   })
@@ -266,7 +267,7 @@ test('ProxyServer gzip session.list 经局域网/CF 入口也剥离（PR #29 补
   await new Promise((resolve) => backend.listen(0, '127.0.0.1', resolve))
   const backendPort = backend.address().port
 
-  const authManager = new AuthManager({ config: { enabled: false } })
+  const authManager = new AuthManager({ sessionsFile: makeSessionsFile(), config: { enabled: false } })
   const proxy = new ProxyServer({
     localPort: 0,
     targetPort: backendPort,

--- a/test/security-vulnerabilities.test.mjs
+++ b/test/security-vulnerabilities.test.mjs
@@ -1,11 +1,12 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 import { AuthManager } from '../lib/auth/manager.js'
+import { makeSessionsFile } from './helpers.mjs'
 import { installBridgeRpc, BRIDGE_ENDPOINTS } from '../lib/bridge-rpc.js'
 import { BridgeService } from '../lib/index.js'
 
 test('P0-1: Custom Tunnel Authentication - prevents loopback bypass when forwarding', () => {
-  const auth = new AuthManager({
+  const auth = new AuthManager({ sessionsFile: makeSessionsFile(),
     config: {
       enabled: true,
       mode: 'token_and_password',
@@ -53,7 +54,7 @@ test('P0-1: Custom Tunnel Authentication - prevents loopback bypass when forward
 })
 
 test('P0-2: Secret Token 严格脱敏与公开状态隔离', () => {
-  const auth = new AuthManager({
+  const auth = new AuthManager({ sessionsFile: makeSessionsFile(),
     config: {
       enabled: true,
       mode: 'token_and_password',
@@ -77,7 +78,7 @@ test('P0-2: Secret Token 严格脱敏与公开状态隔离', () => {
 })
 
 test('P0-3: token_only 模式严格禁止密码登录', async () => {
-  const auth = new AuthManager({
+  const auth = new AuthManager({ sessionsFile: makeSessionsFile(),
     config: {
       enabled: true,
       mode: 'token_only',
@@ -106,7 +107,7 @@ test('P0-3: token_only 模式严格禁止密码登录', async () => {
 })
 
 test('P0-4: RPC 服务端管理员权限校验与主动重新锁定', async () => {
-  const auth = new AuthManager({
+  const auth = new AuthManager({ sessionsFile: makeSessionsFile(),
     config: {
       enabled: true,
       adminPolicy: 'password_unlock',
@@ -208,7 +209,7 @@ test('P0-5: 升级插件命令注入防范与版本正则白名单', async () =>
 })
 
 test('P0-6: Scope 防护范围 Header 伪造防范', () => {
-  const auth = new AuthManager({
+  const auth = new AuthManager({ sessionsFile: makeSessionsFile(),
     config: {
       enabled: true,
       scope: 'lan_only', // 仅对局域网访客开启防护
@@ -232,7 +233,7 @@ test('P0-6: Scope 防护范围 Header 伪造防范', () => {
 })
 
 test('P0-7: Loopback 物理特权 Token 签发与远程/伪造拦截', async () => {
-  const auth = new AuthManager({
+  const auth = new AuthManager({ sessionsFile: makeSessionsFile(),
     config: {
       enabled: true,
       adminPolicy: 'password_unlock',
@@ -255,7 +256,7 @@ test('P0-7: Loopback 物理特权 Token 签发与远程/伪造拦截', async () 
 })
 
 test('P0-8: Workspace RPC checkAdminAuth 权限校验与访客拦截', async () => {
-  const auth = new AuthManager({
+  const auth = new AuthManager({ sessionsFile: makeSessionsFile(),
     config: {
       enabled: true,
       adminPolicy: 'password_unlock',
@@ -321,7 +322,7 @@ test('P0-8: Workspace RPC checkAdminAuth 权限校验与访客拦截', async () 
 })
 
 test('P0-8b: 管理保护独立开关（adminProtection）控制管理操作放行', async () => {
-  const auth = new AuthManager({
+  const auth = new AuthManager({ sessionsFile: makeSessionsFile(),
     config: {
       enabled: false, // 访问认证关闭，但管理保护默认开启
       adminPolicy: 'password_unlock',
@@ -426,7 +427,7 @@ test('P0-10: Rate Limiter 滑动窗口频率限制防护', async () => {
 
 
 test('v2.10.5: authUpdateConfig 守卫 —— 无密码时禁止开启 password_only 防护（防自我锁死）', async () => {
-  const auth = new AuthManager({ config: { mode: 'token_and_password' } }) // 无任何密码
+  const auth = new AuthManager({ sessionsFile: makeSessionsFile(), config: { mode: 'token_and_password' } }) // 无任何密码
   let handlerFn = null
   const mockCtx = {
     connection: {


### PR DESCRIPTION
 Fixes #36

## 问题

`lib/auth/manager.js` 的登录会话是纯内存 `Map`，`_persist()` 只落密码哈希与 secretToken——宿主（dsh web 进程）每次重启，所有已登录设备的 `dsh_bridge_auth` 30 天 cookie 全部失效，必须重新输访问密码（详见 #36）。

## 改动（仅 `lib/auth/manager.js`，4 处）

1. `this.sessions = new Map()` → `PersistentSessionMap.load()`：构造时从 `~/.dsh/dsh-bridge/sessions.json`（与 config.json 同目录，权限 600）恢复，**只恢复结构合法且未过期的会话**；
2. 新增 `PersistentSessionMap`：`set` / `delete` / `clear` 穿透写盘（全量 JSON 落盘，登录会话数量极小，无性能问题）；写盘失败降级为纯内存语义，不阻断认证流程；
3. `dispose()` 不再 `sessions.clear()`：进程退出时内存随进程自然消失，若此处 clear 会把持久化文件一并清空，重启后登录态照样丢；
4. 无新增配置项，行为默认开启。

## 安全语义（全部保持）

- 改密码 / 切模式 / 切 scope / 重新生成 token → `clear()` → 文件同步清空，旧设备全部吊销；
- `validateSession` 的过期校验照旧（恢复时又过滤一遍，双保险）；
- sessionToken 与 secretToken 同级机密（48 位随机 hex），同目录同权限存储，不扩大暴露面；
- `adminSessions`（30 分钟管理解锁）与 `rateLimits`（防爆破）维持纯内存，不受影响。

## 验证

- **单元冒烟 6 场景**：登录落盘 ✓ / 新进程恢复（模拟宿主重启）✓ / 改密码吊销全部会话并清空文件 ✓ / 过期条目恢复时过滤 ✓ / 文件损坏安全降级空 Map ✓ / 落盘失败不阻断认证 ✓
- **真机闭环**（DSH 0.1.2-rc.1 + dsh-bridge 2.10.7 生产环境）：预置 session → 重启 dsh web → 持 cookie 请求 3082 返回 200（正常反代 dsh web 页面，不撞登录墙）；假 token 对照返回 401 登录页。